### PR TITLE
Fix documentation to match SDK implementation

### DIFF
--- a/resources/legacy-sdks-and-migration-guides/sdk-migration-guide.md
+++ b/resources/legacy-sdks-and-migration-guides/sdk-migration-guide.md
@@ -199,8 +199,8 @@ const params = new DynamicAuctionBuilder()
     priceRange: { startPrice: 0.0001, endPrice: 0.01 },
     minProceeds: parseEther('50'),
     maxProceeds: parseEther('500'),
-    durationDays: 7,
-    epochLength: 3600,
+    duration: 7 * 24 * 60 * 60,  // 7 days in seconds
+    epochLength: 43200,  // 12 hours (default)
   })
   .withMigration({
     type: 'uniswapV4',

--- a/sdk/api-reference.md
+++ b/sdk/api-reference.md
@@ -47,7 +47,7 @@ Methods (chainable):
 * `withMarketCapRange({ marketCap: { start, min }, numerairePrice, minProceeds, maxProceeds, duration?, epochLength? })`
   * `marketCap.start` is the starting market cap (auction begins here), `marketCap.min` is the floor price the auction descends to
   * Both values are fully diluted market caps in USD (or whatever unit your numeraire is priced in)
-  * Requires `saleConfig()` and `poolConfig()` first
+  * Requires `saleConfig()` first (do NOT use `poolConfig()` with this method - they are mutually exclusive)
 * `auctionByTicks({ startTick, endTick, minProceeds, maxProceeds, duration?, epochLength?, gamma? })`
 * `withVesting({ duration?, cliffDuration?, recipients?, amounts? })`
 * `withGovernance({ type: 'default' | 'custom' | 'noOp' })`

--- a/sdk/examples/doppler404.md
+++ b/sdk/examples/doppler404.md
@@ -32,8 +32,8 @@ const dynamicBuilder = new DynamicAuctionBuilder()
     startTick, endTick,
     minProceeds: parseEther("100"),
     maxProceeds: parseEther("600"),
-    durationDays: 7,
-    epochLength: 3600,
+    duration: 7 * 24 * 60 * 60,  // 7 days in seconds
+    epochLength: 43200,  // 12 hours (default)
   })
   .withMigration({
     type: 'uniswapV4', fee: 3000, tickSpacing: 60,

--- a/sdk/examples/dynamic-auctions.md
+++ b/sdk/examples/dynamic-auctions.md
@@ -8,7 +8,7 @@ Dynamic auctions are Dutch auctions where the price starts high and descends ove
 
 ## Using market cap targets
 
-`saleConfig()` and `poolConfig()` must be called before `withMarketCapRange()`.
+`saleConfig()` must be called before `withMarketCapRange()`. Note: Do NOT use `poolConfig()` with `withMarketCapRange()` - they are mutually exclusive. Use `poolConfig()` only with `auctionByTicks()` for manual tick configuration.
 
 ```typescript
 import { DopplerSDK } from '@whetstone-research/doppler-sdk';
@@ -51,7 +51,6 @@ async function main() {
       numTokensToSell: parseEther('500000000'),
       numeraire: '0x4200000000000000000000000000000000000006', // WETH on Base
     })
-    .poolConfig({ fee: 3000, tickSpacing: 10 })
     .withMarketCapRange({
       marketCap: { start: 500_000, min: 50_000 }, // $500k start, $50k floor
       numerairePrice: 3000, // ETH = $3000 USD


### PR DESCRIPTION
- Fix epochLength default: 1 hour → 12 hours
- Fix governance API: { useDefaults: true } → { type: 'default' }
- Fix beneficiary type: { address, percentage } → { beneficiary, shares }
- Fix durationDays → duration (in seconds)
- Fix poolConfig/withMarketCapRange mutual exclusion
- Add note: noOp migration not supported for dynamic auctions