### PR TITLE
fix: Update GraphQl docs examples

### DIFF
--- a/reference/api-usage.md
+++ b/reference/api-usage.md
@@ -28,12 +28,12 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
 
 ### Example Queries
 
-1.  **Fetch top 5 pools on Base by USD liquidity:**
+1.  **Fetch top 5 pools on Base Sepolia by USD liquidity:**
 
     ```graphql
     query TopPoolsByLiquidity {
       pools(
-        where: { chainId: 8453 }
+        where: { chainId: 84532 }
         orderBy: "dollarLiquidity"
         orderDirection: "desc"
         limit: 5
@@ -77,7 +77,7 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
 
     ```graphql
     query TokenDetails {
-      token(address: "0x...", chainId: 8453) {
+      token(address: "0x...", chainId: 84532) {
         address
         name
         symbol
@@ -105,16 +105,16 @@ A simple REST endpoint is available for searching tokens.
 * **URL Parameters**:
   * `query`: The search term (e.g., "MyToken", "MTK", or "0x...").
 * **Query Parameters**:
-  * `chain_ids`: A comma-separated list of chain IDs to filter the search (e.g., `?chain_ids=8453,130`).
+  * `chain_ids`: A comma-separated list of chain IDs to filter the search (e.g., `?chain_ids=84532,130`).
 
 **Example Usage:**
 
 ```bash
-# Search for "doppler" token on Base (chain ID 8453)
-curl "http://localhost:42069/search/doppler?chain_ids=8453"
+# Search for "doppler" token on Base Sepolia (chain ID 84532)
+curl "http://localhost:42069/search/doppler?chain_ids=84532"
 
-# Search by contract address on Base and Ink
-curl "http://localhost:42069/search/0x123...abc?chain_ids=8453,57073"
+# Search by contract address on Base Sepolia and Ink
+curl "http://localhost:42069/search/0x123...abc?chain_ids=84532,57073"
 ```
 
 ## Direct SQL Access (Development)

--- a/reference/api-usage.md
+++ b/reference/api-usage.md
@@ -38,14 +38,16 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
         orderDirection: "desc"
         limit: 5
       ) {
-        address
-        dollarLiquidity
-        volumeUsd
-        baseToken {
-          symbol
-        }
-        quoteToken {
-          symbol
+        items {
+          address
+          dollarLiquidity
+          volumeUsd
+          baseToken {
+            symbol
+          }
+          quoteToken {
+            symbol
+          }
         }
       }
     }
@@ -60,12 +62,14 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
         orderDirection: "desc"
         limit: 10
       ) {
-        txHash
-        timestamp
-        type
-        amountIn
-        amountOut
-        usdPrice
+        items {
+          txHash
+          timestamp
+          type
+          amountIn
+          amountOut
+          usdPrice
+        }
       }
     }
     ```
@@ -73,7 +77,7 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
 
     ```graphql
     query TokenDetails {
-      token(id: "0x...") {
+      token(address: "0x...", chainId: 8453) {
         address
         name
         symbol

--- a/reference/api-usage.md
+++ b/reference/api-usage.md
@@ -68,7 +68,7 @@ The primary way to query data is through the GraphQL endpoint, available at `/gr
           type
           amountIn
           amountOut
-          usdPrice
+          swapValueUsd
         }
       }
     }


### PR DESCRIPTION
This PR updates the examples on the api-usage page. Querying the GraphQL API with the current examples returns error responses with no relevant data.

It also appears that usdPrice may have been used in the swap table but is no longer present in ponder.schema.ts in the indexer repo. There is swapValueUsd but I'm not entirely sure if that is the replacement.

### What Changed
- Added `items` wrapper to `pools` and `swaps` queries since Ponder generates paginated responses for collections.
- Changed `id` parameter to `address` and added required `chainId` parameter for `token` query.
- Changed `usdPrice` field to `swapValueUsd` in swaps query.
  - usdPrice is used in the indexer but is not present in the swap table creation in the Ponder schema.


### Changed Files
`reference/api-usage.md`