### PR TITLE
docs: distinguish protocol fees by chain

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -42,7 +42,7 @@ Every token can be created with a unique set of beneficiary addresses that earn 
 
 #### Protocol fee
 
-The Doppler Protocol fee is set to 5% of whatever the newly created token's fees are configured to. For example, if a token is configured with 1% fees, the protocol earns 0.05%.. or a token configured with 0% fees earns the protocol 0%.
+The Doppler Protocol receives 5% of trading fees on EVM and 7.5% on Solana. For example, if a token is configured with a 1% trading fee, the protocol receives 0.05% of swap volume on EVM or 0.075% on Solana. A token configured with a 0% trading fee generates no protocol fees.
 
 ### Governance & Treasury
 


### PR DESCRIPTION
The protocol fee explainer currently presents the EVM 5% fee share as though it applies to every deployment. Solana production is configured to receive 7.5% of trading fees.

This updates the explanation to distinguish the EVM and Solana rates and clarifies that a 1% trading fee corresponds to 0.05% of swap volume on EVM or 0.075% on Solana.

Validation: `git diff --check` and a review of the remaining 5% references, which are EVM-specific or legacy documentation.
