### PR TITLE
update examples for new sdk defaults

### DIFF
--- a/reference/examples/multicurve.md
+++ b/reference/examples/multicurve.md
@@ -8,32 +8,34 @@ description: >-
 ## Using market cap ranges
 
 ```typescript
-import { DopplerSDK } from '@whetstone-research/doppler-sdk';
+import { DopplerSDK, getAddresses } from '@whetstone-research/doppler-sdk/evm';
 import { parseEther, createPublicClient, createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { baseSepolia } from 'viem/chains';
+import { base } from 'viem/chains';
 
 const privateKey = process.env.PRIVATE_KEY as `0x${string}`;
-const rpcUrl = process.env.RPC_URL ?? baseSepolia.rpcUrls.default.http[0];
+const rpcUrl = process.env.RPC_URL ?? base.rpcUrls.default.http[0];
 
 async function main() {
   const account = privateKeyToAccount(privateKey);
 
   const publicClient = createPublicClient({
-    chain: baseSepolia,
+    chain: base,
     transport: http(rpcUrl),
   });
 
   const walletClient = createWalletClient({
-    chain: baseSepolia,
+    chain: base,
     transport: http(rpcUrl),
     account,
   });
 
+  const addresses = getAddresses(base.id);
+
   const sdk = new DopplerSDK({
     publicClient,
     walletClient,
-    chainId: baseSepolia.id,
+    chainId: base.id,
   });
 
   const params = sdk
@@ -46,7 +48,7 @@ async function main() {
     .saleConfig({
       initialSupply: parseEther('1000000000'),
       numTokensToSell: parseEther('900000000'),
-      numeraire: '0x4200000000000000000000000000000000000006', // WETH on Base
+      numeraire: addresses.weth,
     })
     .withCurves({
       numerairePrice: 3000, // ETH = $3000 USD
@@ -104,27 +106,58 @@ main();
 ## Using raw ticks
 
 ```typescript
-import { DopplerSDK, WAD } from '@whetstone-research/doppler-sdk';
-import { parseEther } from 'viem';
+import { DopplerSDK, WAD, getAddresses } from '@whetstone-research/doppler-sdk/evm';
+import { createPublicClient, createWalletClient, http, parseEther } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
 
-const params = sdk
-  .buildMulticurveAuction()
-  .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token.json' })
-  .saleConfig({
-    initialSupply: 1_000_000_000n * WAD,
-    numTokensToSell: 900_000_000n * WAD,
-    numeraire: '0x4200000000000000000000000000000000000006',
-  })
-  .poolConfig({
-    fee: 3000,
-    tickSpacing: 60,
-    curves: [
-      { tickLower: -120000, tickUpper: -90000, numPositions: 8, shares: parseEther('0.4') },
-      { tickLower: -90000, tickUpper: -70000, numPositions: 8, shares: parseEther('0.6') },
-    ],
-  })
-  .withGovernance({ type: 'noOp' })
-  .withMigration({ type: 'uniswapV2' })
-  .withUserAddress(account.address)
-  .build();
+const privateKey = process.env.PRIVATE_KEY as `0x${string}`;
+const rpcUrl = process.env.RPC_URL ?? base.rpcUrls.default.http[0];
+
+async function main() {
+  const account = privateKeyToAccount(privateKey);
+  const addresses = getAddresses(base.id);
+  const publicClient = createPublicClient({
+    chain: base,
+    transport: http(rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    chain: base,
+    transport: http(rpcUrl),
+    account,
+  });
+  const sdk = new DopplerSDK({
+    publicClient,
+    walletClient,
+    chainId: base.id,
+  });
+
+  const params = sdk
+    .buildMulticurveAuction()
+    .tokenConfig({ name: 'My Token', symbol: 'MTK', tokenURI: 'https://example.com/token.json' })
+    .saleConfig({
+      initialSupply: 1_000_000_000n * WAD,
+      numTokensToSell: 900_000_000n * WAD,
+      numeraire: addresses.weth,
+    })
+    .poolConfig({
+      fee: 3000,
+      tickSpacing: 60,
+      curves: [
+        { tickLower: -120000, tickUpper: -90000, numPositions: 8, shares: parseEther('0.4') },
+        { tickLower: -90000, tickUpper: -69960, numPositions: 8, shares: parseEther('0.6') },
+      ],
+    })
+    .withGovernance({ type: 'noOp' })
+    .withMigration({ type: 'uniswapV2' })
+    .withUserAddress(account.address)
+    .build();
+
+  const result = await sdk.factory.createMulticurve(params);
+
+  console.log('Pool ID:', result.poolId);
+  console.log('Token:', result.tokenAddress);
+}
+
+main();
 ```


### PR DESCRIPTION
Adjust example for Base, cleanup defaults, examples work with LTS contracts and Robinhood after [SDK PR](https://github.com/whetstoneresearch/doppler-sdk/pull/178) is merged.