### PR TITLE
docs(reference): organize deployment addresses by environment

### DIFF
--- a/reference/contract-addresses.md
+++ b/reference/contract-addresses.md
@@ -202,6 +202,15 @@ If there are contracts not reflected here but claiming to be instances of Dopple
 | UniswapV3Initializer | [0xaA47...B4e5](https://explorer.inkonchain.com/address/0xaA47D2977d622DBdFD33eeF6a8276727c52EB4e5) | [0x0c83...8259](https://explorer.inkonchain.com/tx/0x0c83df3c4e550810b0b15c48751f4122628d9806b4b9a3b750304ce658f38259) | [9b23399](https://github.com/whetstoneresearch/doppler/commit/9b23399) | 
 | UniswapV4Initializer | [0x014e...d056](https://explorer.inkonchain.com/address/0x014e1c0bd34f3b10546e554cb33b3293fecdd056) | [0x8b0d...49ee](https://explorer.inkonchain.com/tx/0x8b0d5ab9f421605e8deec9a63a37d7d748067f58d970ef9d6899e154d85949ee) | [6e368f4](https://github.com/whetstoneresearch/doppler/commit/6e368f4) | 
 
+### Solana Mainnet
+
+| Program | Address |
+|---|---|
+| Initializer program | [`4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1`](https://explorer.solana.com/address/4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1) |
+| CPMM program | [`5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK`](https://explorer.solana.com/address/5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK) |
+| CPMM migrator program | [`H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o`](https://explorer.solana.com/address/H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o) |
+| Doppler Launch Hook v1 | [`BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr`](https://explorer.solana.com/address/BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr) |
+
 ## Testnet Deployments
 ### Unichain Sepolia (1301)
 | Contract | Address | Transaction | Commit |
@@ -365,18 +374,7 @@ If there are contracts not reflected here but claiming to be instances of Dopple
 | UniswapV4ScheduledMulticurveInitializer | [0xf843...3876](https://sepolia.etherscan.io/address/0xf84378c9f39e0ff267f3101c88773359c5393876) | [0x972a...4de9](https://sepolia.etherscan.io/tx/0x972a11c52ee5a77b8c8ff5490226ec6f435015083150ebddb80a43ef85c44de9) | [787e2df](https://github.com/whetstoneresearch/doppler/commit/787e2df) | 
 | UniswapV4ScheduledMulticurveInitializerHook | [0xc6a5...2dc0](https://sepolia.etherscan.io/address/0xc6a562cb5cbfa29bcb1bdccf903b8b8f2e4a2dc0) | [0x9cc4...53c3](https://sepolia.etherscan.io/tx/0x9cc428598667705087bfae7cdda2929518612ff73080832e1425ed25f2ca53c3) | [787e2df](https://github.com/whetstoneresearch/doppler/commit/787e2df) | 
 
-## Solana Deployments
-
-### Mainnet
-
-| Program | Address |
-|---|---|
-| Initializer program | [`4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1`](https://explorer.solana.com/address/4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1) |
-| CPMM program | [`5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK`](https://explorer.solana.com/address/5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK) |
-| CPMM migrator program | [`H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o`](https://explorer.solana.com/address/H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o) |
-| Doppler Launch Hook v1 | [`BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr`](https://explorer.solana.com/address/BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr) |
-
-### Devnet
+### Solana Devnet
 
 | Program | Address |
 |---|---|

--- a/snippets/solana-devnet-deployments.md
+++ b/snippets/solana-devnet-deployments.md
@@ -1,15 +1,4 @@
-## Solana Deployments
-
-### Mainnet
-
-| Program | Address |
-|---|---|
-| Initializer program | [`4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1`](https://explorer.solana.com/address/4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1) |
-| CPMM program | [`5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK`](https://explorer.solana.com/address/5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK) |
-| CPMM migrator program | [`H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o`](https://explorer.solana.com/address/H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o) |
-| Doppler Launch Hook v1 | [`BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr`](https://explorer.solana.com/address/BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr) |
-
-### Devnet
+### Solana Devnet
 
 | Program | Address |
 |---|---|

--- a/snippets/solana-mainnet-deployments.md
+++ b/snippets/solana-mainnet-deployments.md
@@ -1,0 +1,8 @@
+### Solana Mainnet
+
+| Program | Address |
+|---|---|
+| Initializer program | [`4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1`](https://explorer.solana.com/address/4carc9eePfE7jKUXdCAYMhcPf4awEFpZPrz1sTykdss1) |
+| CPMM program | [`5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK`](https://explorer.solana.com/address/5pXzd9UiWrVxATCYWmgo5EbfxzXqHYhfSKGdCPXPz7vK) |
+| CPMM migrator program | [`H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o`](https://explorer.solana.com/address/H71WD4tsiCCipro4urykWHySH1ryvLTmqEdNbHTGwb3o) |
+| Doppler Launch Hook v1 | [`BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr`](https://explorer.solana.com/address/BeyqffXEVgLpM3fQ1zjk8YnZzQN9sMVrCKtNKwSxNATr) |


### PR DESCRIPTION
## Summary

Groups network deployment entries under the existing Mainnet and Testnet sections. The source fragments are separated by network so automated updates can preserve that organization.