### PR TITLE
docs(solana): explain fees and cosigning

### DIFF
--- a/reference/svm-sdk-examples/README.md
+++ b/reference/svm-sdk-examples/README.md
@@ -6,6 +6,20 @@ icon: qrcode-read
 
 These examples show how to create and trade Doppler launches on Solana.
 
+## Fee settings
+
+Each Solana launch chooses a standard trading fee when it is created. The current allowed range is `0.10%-5.00%`. The fee is paid in the token being sold: buys generate fees in SOL or USDC, while sells generate fees in the launched token.
+
+Doppler receives `7.50%` of each collected trading fee, and the remainder goes to the beneficiaries selected for the launch. This is a share of the fee, not an additional fee on the trade. For example, with a `1%` trading fee, Doppler receives `0.075%` of the trade.
+
+A launch's fee settings are saved when it is created, so later changes to the network settings apply only to new launches. A launch may also use a fee that decreases over time. It can begin anywhere from `0%` to `100%`, including above the standard fee range, but it can never reduce the fee below the launch's standard fee. See [Dynamic fee launch](dynamic-fee-launch.md).
+
+## Cosigning
+
+Doppler Launch Hook v1 can optionally require Doppler approval for each buy or sell. This protection works with either standard or time-based fees. It can end at a chosen time or remain active indefinitely; once it expires, trading continues normally without approval. Creating the launch and claiming fees do not require cosigning.
+
+The standard SDK selects a cosigner already approved by Doppler. A launch creator cannot authorize a new cosigner simply by supplying an address. Integrators that need to run their own approval service must coordinate a separate approved setup with Doppler.
+
 * [Launch](launch.md) - create a standard Solana launch.
 * [Dynamic fee launch](dynamic-fee-launch.md) - create a launch with a decaying swap fee schedule, optionally combined with cosigner gating.
 * [Swap](swap.md) - swap against a Solana CPMM pool.

--- a/reference/svm-sdk-examples/README.md
+++ b/reference/svm-sdk-examples/README.md
@@ -16,9 +16,11 @@ A launch's fee settings are saved when it is created, so later changes to the ne
 
 ## Cosigning
 
-Doppler Launch Hook v1 can optionally require Doppler approval for each buy or sell. This protection works with either standard or time-based fees. It can end at a chosen time or remain active indefinitely; once it expires, trading continues normally without approval. Creating the launch and claiming fees do not require cosigning.
+Cosigning is an optional transaction approval layer for a launch. While it is enabled, each swap must include a signature from an approved cosigner before Doppler accepts it. The cosigner does not take custody of the user's tokens or submit the trade for them; it only confirms that the transaction is allowed under the launch's trading policy.
 
-The standard SDK selects a cosigner already approved by Doppler. A launch creator cannot authorize a new cosigner simply by supplying an address. Integrators that need to run their own approval service must coordinate a separate approved setup with Doppler.
+A cosigning gate can end at a chosen time or remain active indefinitely, and it works with either standard or time-based fees. Once an expiring gate ends, trading continues normally without approval. Creating a launch and claiming fees do not require cosigning.
+
+The standard SDK selects a cosigner already approved by Doppler; supplying an address does not register a new cosigner. Teams interested in cosigning, running their own approval service, or discussing a custom setup can contact [contact@whetstone.cc](mailto:contact@whetstone.cc).
 
 * [Launch](launch.md) - create a standard Solana launch.
 * [Dynamic fee launch](dynamic-fee-launch.md) - create a launch with a decaying swap fee schedule, optionally combined with cosigner gating.

--- a/reference/svm-sdk-examples/dynamic-fee-launch.md
+++ b/reference/svm-sdk-examples/dynamic-fee-launch.md
@@ -4,7 +4,7 @@ description: Create a Solana launch with a dynamic fee schedule
 
 # Dynamic Fee Launch
 
-Pass `dynamicFee` to `createLaunch` to configure a fee schedule on the Doppler CPMM hook. The hook normalizes the schedule during the `BEFORE_CREATE` callback and stores the normalized schedule in the launch hook payload.
+Pass `dynamicFee` to `createLaunch` to configure a fee schedule on Doppler Launch Hook v1. The hook normalizes the schedule during the `BEFORE_CREATE` callback and stores the normalized schedule in the launch hook payload.
 
 This snippet assumes `payer` and `rpc` are already initialized with `@solana/kit`.
 
@@ -15,7 +15,7 @@ import {
 } from '@solana/kit';
 import {
   createLaunch,
-  cpmmHook,
+  dopplerLaunchHookV1,
   initializer,
   deriveSolanaCpmmDeployment,
   DOPPLER_SOLANA_DEVNET_PROGRAM_ADDRESSES,
@@ -79,13 +79,13 @@ const { instruction } = await createLaunch({
 });
 ```
 
-Submit the returned `instruction` with the generated mint and vault signers. The SDK sets the CPMM hook program, `HF_BEFORE_CREATE | HF_BEFORE_SWAP`, the 32-byte schedule payload, the create-hook account commitment, and the swap hook remaining-account commitment.
+Submit the returned `instruction` with the generated mint and vault signers. The SDK sets the Doppler Launch Hook v1 program, `HF_BEFORE_CREATE | HF_BEFORE_SWAP`, the 32-byte schedule payload, the create-hook account commitment, and the swap hook remaining-account commitment.
 
 `startingTime: 0n` means the hook should start the schedule at launch creation. During `initialize_launch`, the hook replaces it with the current Solana clock timestamp before the launch account is stored.
 
 The effective swap fee is the greater of the current schedule fee and the launch's static `swapFeeBps`, so the schedule cannot reduce the fee below the static launch fee.
 
-After sending the transaction, you can verify that the launch is using the CPMM hook:
+After sending the transaction, you can verify that the launch is using Doppler Launch Hook v1:
 
 ```typescript
 const launch = await initializer.fetchLaunch(rpc, addresses.launch, {
@@ -100,18 +100,23 @@ const hookPayload = new Uint8Array(
   launch.hookPayload.bytes.slice(0, launch.hookPayload.len),
 );
 
-if (launch.hookProgram !== deployment.cpmmHookProgram) {
-  throw new Error('Launch is not using the CPMM hook');
+if (launch.hookProgram !== deployment.dopplerLaunchHookV1Program) {
+  throw new Error('Launch is not using Doppler Launch Hook v1');
 }
 
-if (!cpmmHook.isDynamicFeeSchedulePayload(hookPayload)) {
+if (!dopplerLaunchHookV1.isDynamicFeeSchedulePayload(hookPayload)) {
   throw new Error('Launch hook payload does not contain a dynamic fee schedule');
 }
 ```
 
-To combine dynamic fees with cosigner gating, pass the same dynamic fee schedule plus `cosigner` and, optionally, `cosignGateExpiresAt`:
+To combine dynamic fees with cosigner gating, first resolve the Doppler-managed gate from its on-chain config, then pass it with the schedule:
 
 ```typescript
+const cosignerGate =
+  await dopplerLaunchHookV1.resolveManagedCosignerGate(rpc, {
+    expiresAt: BigInt(Math.floor(Date.now() / 1_000) + 60 * 60),
+  });
+
 const { instruction } = await createLaunch({
   // ...same launch inputs as above
   dynamicFee: {
@@ -120,9 +125,8 @@ const { instruction } = await createLaunch({
     endFeeBps: 200,
     durationSeconds: 10n * 60n,
   },
-  cosigner,
-  cosignGateExpiresAt,
+  cosignerGate,
 });
 ```
 
-With both features enabled, swaps require the configured cosigner until expiry, and the dynamic fee schedule continues to apply throughout the initializer trading phase. Omit `cosignGateExpiresAt` for an indefinite gate; in that case the schedule remains the entire hook payload and the presence of the cosigner config account enables gating.
+With both features enabled, swaps require the configured cosigner until expiry, and the dynamic fee schedule continues to apply throughout the Initializer trading phase. Omit `expiresAt` when resolving the gate to require cosigning indefinitely. The resolver selects an active cosigner already authorized by the hook config; it does not register a caller-provided key.


### PR DESCRIPTION
## Summary

Adds a brief, non-technical overview of Solana trading fees using the current production configuration: a `0.10%-5.00%` standard fee range and a `7.50%` Doppler share of collected fees. It also explains time-based fees and optional cosigning, including what happens after the gate expires and how integrators can use their own approval service.

Updates the dynamic-fee example to use Doppler Launch Hook v1 and the current managed-cosigner SDK API.

## Validation

`git diff --check`
